### PR TITLE
Update mercurius.py

### DIFF
--- a/mercurius.py
+++ b/mercurius.py
@@ -343,6 +343,8 @@ class FIR_SED_fit:
         self.mnrfol = mnrfol
         if "fit" in self.l0_list:
             self.fit_l0 = True
+        else:
+            self.fit_l0 = False
 
         if fluxdens_unit:
             assert fluxdens_unit in ["Jy", "mJy", "muJy", "nJy"]


### PR DESCRIPTION
small fix of error saying that there is no attribute called 'fit_l0' in FIR_SED_fit when making a corner plot without 'fit' in the l0_list